### PR TITLE
switch to cryptography

### DIFF
--- a/certipy/__init__.py
+++ b/certipy/__init__.py
@@ -11,11 +11,6 @@
 ###############################################################################
 
 from certipy.certipy import (
-   TLSFileType, TLSFile, TLSFileBundle, CertStore, open_tls_file,
-   CertNotFoundError, CertExistsError, CertificateAuthorityInUseError, Certipy
-)
-
-__all__ = (
-   TLSFileType, TLSFile, TLSFileBundle, CertStore, open_tls_file,
+   TLSFileType, TLSFile, TLSFileBundle, CertStore, open_tls_file, KeyType,
    CertNotFoundError, CertExistsError, CertificateAuthorityInUseError, Certipy
 )

--- a/certipy/command_line.py
+++ b/certipy/command_line.py
@@ -11,11 +11,10 @@
 ###############################################################################
 
 import argparse
-import shutil
 import sys
-from OpenSSL import crypto
+
 from certipy import (
-    Certipy, CertExistsError, CertNotFoundError, CertificateAuthorityInUseError
+    Certipy, CertExistsError, CertNotFoundError, CertificateAuthorityInUseError, KeyType
 )
 
 def main():
@@ -36,8 +35,8 @@ def main():
     parser.add_argument(
         '--rm', action="store_true", help="Remove the cert specified by name.")
     parser.add_argument(
-        '--cert-type', default="rsa", choices=['rsa', 'dsa'],
-        help="The type of cert to create.")
+        '--cert-type', default="rsa", choices=[t.value for t in KeyType],
+        help="The type of key to create.")
     parser.add_argument(
         '--bits', type=int, default=2048, help="The number of bits to use.")
     parser.add_argument(
@@ -52,7 +51,6 @@ def main():
     args = parser.parse_args()
 
     certipy = Certipy(store_dir=args.store_dir)
-    cert_type = crypto.TYPE_RSA if args.cert_type == "rsa" else crypto.TYPE_DSA
     record = None
 
     if args.rm:
@@ -74,7 +72,7 @@ def main():
         if ca_record:
             try:
                 record = certipy.create_signed_pair(
-                    args.name, args.ca_name, cert_type=cert_type,
+                    args.name, args.ca_name, cert_type=args.cert_type,
                     bits=args.bits, years=args.valid,
                     alt_names=alt_names, overwrite=args.overwrite)
             except CertExistsError as e:

--- a/certipy/test/test_certipy.py
+++ b/certipy/test/test_certipy.py
@@ -13,15 +13,11 @@
 import os
 import pytest
 import requests
-import shutil
 import socket
 import ssl
 from contextlib import closing, contextmanager
 from datetime import datetime, timedelta, timezone
 from flask import Flask
-from pytest import fixture
-from OpenSSL import crypto
-from pathlib import Path
 from requests.exceptions import SSLError
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from threading import Thread

--- a/certipy/test/test_certipy.py
+++ b/certipy/test/test_certipy.py
@@ -12,11 +12,16 @@
 
 import os
 import pytest
-import shutil
-from pytest import fixture
-from OpenSSL import crypto
-from pathlib import Path
+from datetime import datetime, timedelta, timezone
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+from pytest import fixture
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from ipaddress import ip_address
 
 from ..certipy import (
    TLSFileType, TLSFile, TLSFileBundle, CertStore, open_tls_file,
@@ -25,33 +30,28 @@ from ..certipy import (
 
 @fixture(scope='module')
 def signed_key_pair():
-    pkey = crypto.PKey()
-    pkey.generate_key(crypto.TYPE_RSA, 2048)
-    req = crypto.X509Req()
-    subj = req.get_subject()
-
-    setattr(subj, 'CN', 'test')
-
-    req.set_pubkey(pkey)
-    req.sign(pkey, 'sha256')
-
-    issuer_cert, issuer_key = (req, pkey)
-    not_before, not_after = (0, 60*60*24*365*2)
-    cert = crypto.X509()
-    cert.set_serial_number(0)
-    cert.gmtime_adj_notBefore(not_before)
-    cert.gmtime_adj_notAfter(not_after)
-    cert.set_issuer(issuer_cert.get_subject())
-    cert.set_subject(req.get_subject())
-    cert.set_pubkey(req.get_pubkey())
-
-    cert.sign(issuer_key, 'sha256')
+    pkey = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    subject = issuer = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, "test")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(pkey.public_key())
+        .serial_number(1)
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365 * 2))
+        .sign(pkey, hashes.SHA256())
+    )
     return (pkey, cert)
+
 
 @fixture(scope='module')
 def record():
     return {
-        'serial': 0,
+        'serial': 1,
         'parent_ca': '',
         'signees': None,
         'files': {
@@ -62,7 +62,7 @@ def record():
     }
 
 
-def test_tls_context_manager():
+def test_tls_context_manager(tmp_path):
     def simple_perms(f):
         return oct(os.stat(f).st_mode & 0o777)
 
@@ -71,11 +71,11 @@ def test_tls_context_manager():
         with open_tls_file('foo.test', 'r') as tlsfh:
             pass
 
-    with NamedTemporaryFile('w') as fh:
+    with NamedTemporaryFile('w', dir=str(tmp_path)) as fh:
         with open_tls_file(fh.name, 'r') as tlsfh:
             pass
     # write
-    with NamedTemporaryFile('w') as fh:
+    with NamedTemporaryFile('w', dir=str(tmp_path)) as fh:
         containing_dir = os.path.dirname(fh.name)
         # public certificate
         with open_tls_file(fh.name, 'w', private=False) as tlsfh:
@@ -90,10 +90,10 @@ def test_tls_context_manager():
         assert simple_perms(fh.name) == '0o600'
 
 
-def test_tls_file(signed_key_pair):
+def test_tls_file(signed_key_pair, tmp_path):
     key, cert = signed_key_pair
     def read_write_key(file_type):
-        with NamedTemporaryFile('w') as fh:
+        with NamedTemporaryFile('w', dir=str(tmp_path)) as fh:
             tlsfile = TLSFile(fh.name, file_type=file_type)
             # test persist to disk
             x509 = cert if file_type is TLSFileType.CERT else key
@@ -125,10 +125,12 @@ def test_tls_file_bundle(signed_key_pair, record):
 
 def test_certipy_store(signed_key_pair, record):
     key, cert = signed_key_pair
-    key_str = crypto.dump_privatekey(crypto.FILETYPE_PEM, key)\
-                .decode('utf-8')
-    cert_str = crypto.dump_certificate(crypto.FILETYPE_PEM, cert)\
-                .decode('utf-8')
+    key_str = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    cert_str = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
     with TemporaryDirectory() as td:
         common_name = 'foo'
         store = CertStore(containing_dir=td)
@@ -174,7 +176,7 @@ def test_certipy():
         # create a CA
         ca_name = 'foo'
         certipy = Certipy(store_dir=td)
-        ca_record = certipy.create_ca(ca_name, pathlen=-1)
+        ca_record = certipy.create_ca(ca_name, pathlen=None)
 
         non_empty_paths = [f for f in ca_record['files'].values() if f]
         assert len(non_empty_paths) == 2
@@ -197,14 +199,14 @@ def test_certipy():
         assert cert_record['files']['ca'] == ca_record['files']['cert']
 
         cert_bundle = certipy.store.get_files(cert_name)
-        stored_alt_names = cert_bundle.cert.get_extension_value(
-            'subjectAltName')
+        cert_bundle.cert.load()
 
-        assert alt_names[0] in stored_alt_names
-        # For some reason, the string representation changes IP: to
-        # IP Address:... the important part is that the actual IP is in the
-        # extension.
-        assert alt_names[1][3:] in stored_alt_names
+        subject_alt = cert_bundle.cert.get_extension_value(x509.SubjectAlternativeName)
+        assert subject_alt is not None
+        assert subject_alt.get_values_for_type(x509.IPAddress) == [
+            ip_address("10.10.10.10")
+        ]
+        assert subject_alt.get_values_for_type(x509.DNSName) == ["bar.example.com"]
 
 
         # add a second CA
@@ -254,7 +256,7 @@ def test_certipy():
         assert end_ca_signee_num > begin_ca_signee_num
         assert intermediate_ca_bundle.record['parent_ca'] == ca_name
         assert intermediate_ca_bundle.is_ca()
-        assert 'pathlen:1' in basic_constraints
+        assert basic_constraints.path_length == 1
 
 def test_certipy_trust_graph():
     trust_graph = {

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
 
     packages=find_packages(exclude=['contrib', 'docs', 'test']),
 
-    install_requires=['pyopenssl'],
+    install_requires=['cryptography', 'ipaddress'],
 
     extras_require={
         'dev': ['pytest'],


### PR DESCRIPTION
trades deprecated PyOpenSSL x509 APIs for [cryptography](https://cryptography.io).

Attempts to minimize breakages, since most changes are internal, but some things are changed. As far as I can tell, actual user-consumed APIs are unchanged. The JupyterHub internal SSL tests pass without modification, for example.

Previous arguments are supported as much as possible, with some deprecations where appropriate (e.g. openssl integer enums for our own string enums). Some shims and mappings are added to continue accepting string inputs like `CN="name"` and `IP:127.0.0.1`, turning them into what `cryptography.x509` accepts, since it has a much stricter, more explicit API.

Return types that returned the underlying OpenSSL.crypto objects now return the cryptography.x509 objects. That seems unavoidable, but I doubt the APIs that return or accept `crypto` objects themselves are much used outside certipy, if at all.

Some technically public APIs are changed (though likely not used) include get_extension_value, which now returns cryptography.x509 ExtensionType objects instead of strings, and the format of the extensions list in `sign` is changed for compatibility.

Support dropped for things I doubt are used, based on my reading of what was accepted (though never tested):

- DSA keys (deprecated in OpenSSL 7, anyway)
- TEXT cert encoding (I don't know what this is, not sure if it ever made sense)

closes #8 