### PR TITLE
add __main__ for python -m certipy

### DIFF
--- a/certipy/__main__.py
+++ b/certipy/__main__.py
@@ -1,0 +1,4 @@
+from certipy.command_line import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
so `python3 -m certipy` does the same thing as `certipy`