### PR TITLE
Add `pre-commit` config and format and fix files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.2
+    hooks:
+      - id: ruff
+        types:
+          - python
+        args: ["--fix", "--show-fixes"]
+      - id: ruff-format
+        types:
+          - python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,6 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.2
     hooks:

--- a/certipy/__init__.py
+++ b/certipy/__init__.py
@@ -11,6 +11,27 @@
 ###############################################################################
 
 from certipy.certipy import (
-   TLSFileType, TLSFile, TLSFileBundle, CertStore, open_tls_file, KeyType,
-   CertNotFoundError, CertExistsError, CertificateAuthorityInUseError, Certipy
+    TLSFileType,
+    TLSFile,
+    TLSFileBundle,
+    CertStore,
+    open_tls_file,
+    KeyType,
+    CertNotFoundError,
+    CertExistsError,
+    CertificateAuthorityInUseError,
+    Certipy,
 )
+
+__all__ = [
+    TLSFileType,
+    TLSFile,
+    TLSFileBundle,
+    CertStore,
+    open_tls_file,
+    KeyType,
+    CertNotFoundError,
+    CertExistsError,
+    CertificateAuthorityInUseError,
+    Certipy,
+]

--- a/certipy/command_line.py
+++ b/certipy/command_line.py
@@ -14,8 +14,12 @@ import argparse
 import sys
 
 from certipy import (
-    Certipy, CertExistsError, CertNotFoundError, CertificateAuthorityInUseError, KeyType
+    Certipy,
+    CertExistsError,
+    CertificateAuthorityInUseError,
+    KeyType,
 )
+
 
 def main():
     describe_certipy = """
@@ -23,30 +27,42 @@ def main():
     """
     parser = argparse.ArgumentParser(description=describe_certipy)
     parser.add_argument(
-        'name', help="""Name of the cert to create,
+        "name",
+        help="""Name of the cert to create,
                         defaults to creating a CA cert. If no signing
-                        --ca-name specified.""")
+                        --ca-name specified.""",
+    )
     parser.add_argument(
-        '--ca-name', help="The name of the CA to sign this cert." , default="")
+        "--ca-name", help="The name of the CA to sign this cert.", default=""
+    )
     parser.add_argument(
-        '--overwrite',
+        "--overwrite",
         action="store_true",
-        help="If the cert already exists, bump the serial and overwrite it.")
+        help="If the cert already exists, bump the serial and overwrite it.",
+    )
     parser.add_argument(
-        '--rm', action="store_true", help="Remove the cert specified by name.")
+        "--rm", action="store_true", help="Remove the cert specified by name."
+    )
     parser.add_argument(
-        '--cert-type', default="rsa", choices=[t.value for t in KeyType],
-        help="The type of key to create.")
+        "--cert-type",
+        default="rsa",
+        choices=[t.value for t in KeyType],
+        help="The type of key to create.",
+    )
     parser.add_argument(
-        '--bits', type=int, default=2048, help="The number of bits to use.")
+        "--bits", type=int, default=2048, help="The number of bits to use."
+    )
     parser.add_argument(
-        '--valid', type=int, default=5, help="Years the cert is valid for.")
+        "--valid", type=int, default=5, help="Years the cert is valid for."
+    )
     parser.add_argument(
-        '--alt-names', default="",
-        help="Alt names for the certificate (comma delimited).")
+        "--alt-names",
+        default="",
+        help="Alt names for the certificate (comma delimited).",
+    )
     parser.add_argument(
-        '--store-dir', default="out",
-        help="The location for the store and certs.")
+        "--store-dir", default="out", help="The location for the store and certs."
+    )
 
     args = parser.parse_args()
 
@@ -65,28 +81,38 @@ def main():
 
     alt_names = None
     if args.alt_names:
-        alt_names = [_.strip() for _ in args.alt_names.split(',')]
+        alt_names = [_.strip() for _ in args.alt_names.split(",")]
 
     if args.ca_name:
         ca_record = certipy.store.get_record(args.ca_name)
         if ca_record:
             try:
                 record = certipy.create_signed_pair(
-                    args.name, args.ca_name, cert_type=args.cert_type,
-                    bits=args.bits, years=args.valid,
-                    alt_names=alt_names, overwrite=args.overwrite)
+                    args.name,
+                    args.ca_name,
+                    cert_type=args.cert_type,
+                    bits=args.bits,
+                    years=args.valid,
+                    alt_names=alt_names,
+                    overwrite=args.overwrite,
+                )
             except CertExistsError as e:
                 print(e)
         else:
             print(
                 "CA {} not found. Must specify an exisiting authority to"
-                " sign this cert.".format(args.ca_name))
+                " sign this cert.".format(args.ca_name)
+            )
     else:
         try:
             record = certipy.create_ca(
-                args.name, cert_type=cert_type, bits=args.bits,
-                years=args.valid, alt_names=alt_names,
-                overwrite=args.overwrite)
+                args.name,
+                cert_type=args.cert_type,
+                bits=args.bits,
+                years=args.valid,
+                alt_names=alt_names,
+                overwrite=args.overwrite,
+            )
         except CertExistsError as e:
             print(e)
 

--- a/certipy/test/test_certipy.py
+++ b/certipy/test/test_certipy.py
@@ -19,7 +19,7 @@ from contextlib import closing, contextmanager
 from datetime import datetime, timedelta, timezone
 from flask import Flask
 from requests.exceptions import SSLError
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 from threading import Thread
 from werkzeug.serving import make_server
 
@@ -32,14 +32,18 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from ipaddress import ip_address
 
 from ..certipy import (
-   TLSFileType, TLSFile, TLSFileBundle, CertStore, open_tls_file,
-   CertExistsError, Certipy
+    TLSFileType,
+    TLSFile,
+    TLSFileBundle,
+    CertStore,
+    open_tls_file,
+    Certipy,
 )
 
 
 def find_free_port():
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(('localhost', 0))
+        s.bind(("localhost", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
 
@@ -47,19 +51,21 @@ def find_free_port():
 def make_flask_app():
     app = Flask(__name__)
 
-    @app.route('/')
+    @app.route("/")
     def working():
         return "working"
 
 
 @contextmanager
-def tls_server(certfile: str, keyfile: str, host: str = 'localhost', port: int = 0):
+def tls_server(certfile: str, keyfile: str, host: str = "localhost", port: int = 0):
     if port == 0:
         port = find_free_port()
 
     ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
     ssl_context.load_cert_chain(certfile, keyfile)
-    server = make_server(host, port, make_flask_app(), ssl_context=ssl_context, threaded=True)
+    server = make_server(
+        host, port, make_flask_app(), ssl_context=ssl_context, threaded=True
+    )
     t = Thread(target=server.serve_forever)
     t.start()
     try:
@@ -77,7 +83,8 @@ def fake_cert_file(tmp_path):
     filename.touch()
     return filename
 
-@fixture(scope='module')
+
+@fixture(scope="module")
 def signed_key_pair():
     pkey = rsa.generate_private_key(
         public_exponent=65537,
@@ -97,16 +104,16 @@ def signed_key_pair():
     return (pkey, cert)
 
 
-@fixture(scope='module')
+@fixture(scope="module")
 def record():
     return {
-        'serial': 1,
-        'parent_ca': '',
-        'signees': None,
-        'files': {
-            'key': 'out/foo.key',
-            'cert': 'out/foo.crt',
-            'ca': 'out/ca.crt',
+        "serial": 1,
+        "parent_ca": "",
+        "signees": None,
+        "files": {
+            "key": "out/foo.key",
+            "cert": "out/foo.crt",
+            "ca": "out/ca.crt",
         },
     }
 
@@ -116,36 +123,37 @@ def test_tls_context_manager(fake_cert_file):
         return oct(os.stat(f).st_mode & 0o777)
 
     # read
-    with pytest.raises(OSError) as e:
-        with open_tls_file('foo.test', 'r') as tlsfh:
+    with pytest.raises(OSError):
+        with open_tls_file("foo.test", "r"):
             pass
 
-    with open_tls_file(fake_cert_file, 'r') as tlsfh:
+    with open_tls_file(fake_cert_file, "r"):
         pass
 
     # write
     containing_dir = os.path.dirname(fake_cert_file)
     # public certificate
-    with open_tls_file(fake_cert_file, 'w', private=False) as tlsfh:
-        assert simple_perms(containing_dir) == '0o755'
+    with open_tls_file(fake_cert_file, "w", private=False):
+        assert simple_perms(containing_dir) == "0o755"
 
-    assert simple_perms(fake_cert_file) == '0o644'
+    assert simple_perms(fake_cert_file) == "0o644"
 
     # private certificate
-    with open_tls_file(fake_cert_file, 'w') as tlsfh:
-        assert simple_perms(containing_dir) == '0o755'
+    with open_tls_file(fake_cert_file, "w"):
+        assert simple_perms(containing_dir) == "0o755"
 
-    assert simple_perms(fake_cert_file) == '0o600'
+    assert simple_perms(fake_cert_file) == "0o600"
 
 
 def test_tls_file(signed_key_pair, fake_cert_file):
     key, cert = signed_key_pair
+
     def read_write_key(file_type):
         tlsfile = TLSFile(fake_cert_file, file_type=file_type)
         # test persist to disk
         x509 = cert if file_type is TLSFileType.CERT else key
         tlsfile.save(x509)
-        with open(fake_cert_file, 'r') as f:
+        with open(fake_cert_file, "r") as f:
             assert f.read() is not None
         # test load from disk
         loaded_tlsfile = TLSFile(fake_cert_file, file_type=file_type)
@@ -158,17 +166,19 @@ def test_tls_file(signed_key_pair, fake_cert_file):
     # private key
     read_write_key(TLSFileType.KEY)
 
+
 def test_tls_file_bundle(signed_key_pair, record):
     key, cert = signed_key_pair
     # from record
-    bundle = TLSFileBundle('foo').from_record(record)
+    bundle = TLSFileBundle("foo").from_record(record)
     assert bundle.key and bundle.cert and bundle.ca
 
     # to record
     exported_record = bundle.to_record()
-    f_types = {key for key in exported_record['files'].keys()}
+    f_types = {key for key in exported_record["files"].keys()}
     assert len(f_types) == 3
-    assert f_types == {'key', 'cert', 'ca'}
+    assert f_types == {"key", "cert", "ca"}
+
 
 def test_certipy_store(signed_key_pair, record):
     key, cert = signed_key_pair
@@ -179,13 +189,13 @@ def test_certipy_store(signed_key_pair, record):
     ).decode("utf-8")
     cert_str = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
     with TemporaryDirectory() as td:
-        common_name = 'foo'
+        common_name = "foo"
         store = CertStore(containing_dir=td)
         # add files
         x509s = {
-            'key': key,
-            'cert': cert,
-            'ca': None,
+            "key": key,
+            "cert": cert,
+            "ca": None,
         }
         store.add_files(common_name, x509s)
 
@@ -204,46 +214,48 @@ def test_certipy_store(signed_key_pair, record):
 
         # check the record for those files
         main_record = store.get_record(common_name)
-        non_empty_paths = [f for f in main_record['files'].values() if f]
+        non_empty_paths = [f for f in main_record["files"].values() if f]
         assert len(non_empty_paths) == 2
 
         # add another record with no physical files
-        signee_common_name = 'bar'
+        signee_common_name = "bar"
         store.add_record(signee_common_name, record=record)
 
         # 'sign' cert
         store.add_sign_link(common_name, signee_common_name)
         signee_record = store.get_record(signee_common_name)
-        assert len(main_record['signees']) == 1
-        assert signee_record['parent_ca'] == common_name
+        assert len(main_record["signees"]) == 1
+        assert signee_record["parent_ca"] == common_name
+
 
 def test_certipy():
     # FIXME: unfortunately similar names...either separate tests or rename
     with TemporaryDirectory() as td:
         # create a CA
-        ca_name = 'foo'
+        ca_name = "foo"
         certipy = Certipy(store_dir=td)
         ca_record = certipy.create_ca(ca_name, pathlen=None)
 
-        non_empty_paths = [f for f in ca_record['files'].values() if f]
+        non_empty_paths = [f for f in ca_record["files"].values() if f]
         assert len(non_empty_paths) == 2
 
         # check that the paths are backed by actual files
         ca_bundle = certipy.store.get_files(ca_name)
         assert ca_bundle.key.load() is not None
         assert ca_bundle.cert.load() is not None
-        assert 'PRIVATE' in str(ca_bundle.key)
-        assert 'CERTIFICATE' in str(ca_bundle.cert)
+        assert "PRIVATE" in str(ca_bundle.key)
+        assert "CERTIFICATE" in str(ca_bundle.cert)
 
         # create a cert and sign it with that CA
-        cert_name = 'bar'
-        alt_names = ['DNS:bar.example.com', 'IP:10.10.10.10']
+        cert_name = "bar"
+        alt_names = ["DNS:bar.example.com", "IP:10.10.10.10"]
         cert_record = certipy.create_signed_pair(
-                cert_name, ca_name, alt_names=alt_names)
+            cert_name, ca_name, alt_names=alt_names
+        )
 
-        non_empty_paths = [f for f in cert_record['files'].values() if f]
+        non_empty_paths = [f for f in cert_record["files"].values() if f]
         assert len(non_empty_paths) == 3
-        assert cert_record['files']['ca'] == ca_record['files']['cert']
+        assert cert_record["files"]["ca"] == ca_record["files"]["cert"]
 
         cert_bundle = certipy.store.get_files(cert_name)
         cert_bundle.cert.load()
@@ -255,18 +267,17 @@ def test_certipy():
         ]
         assert subject_alt.get_values_for_type(x509.DNSName) == ["bar.example.com"]
 
-
         # add a second CA
-        ca_name1 = 'baz'
+        ca_name1 = "baz"
         certipy.create_ca(ca_name1)
 
         # create a bundle from all known certs
-        bundle_file_name = 'bundle.crt'
+        bundle_file_name = "bundle.crt"
         bundle_file = certipy.create_ca_bundle(bundle_file_name)
         ca_bundle1 = certipy.store.get_files(ca_name1)
         ca_bundle1.cert.load()
         assert bundle_file is not None
-        with open(bundle_file, 'r') as fh:
+        with open(bundle_file, "r") as fh:
             all_certs = fh.read()
 
             # should contain both CA certs
@@ -274,42 +285,42 @@ def test_certipy():
             assert str(ca_bundle1.cert) in all_certs
 
         # bundle of CA certs for only a single name this time
-        bundle_file = certipy.create_ca_bundle_for_names(bundle_file_name,
-                ['bar'])
+        bundle_file = certipy.create_ca_bundle_for_names(bundle_file_name, ["bar"])
         assert bundle_file is not None
-        with open(bundle_file, 'r') as fh:
+        with open(bundle_file, "r") as fh:
             all_certs = fh.read()
             assert str(ca_bundle.cert) in all_certs
             assert str(ca_bundle1.cert) not in all_certs
 
         # delete certs
-        deleted_record = certipy.store.remove_files('bar', delete_dir=True)
-        assert not os.path.exists(deleted_record['files']['cert'])
-        assert not os.path.exists(deleted_record['files']['key'])
+        deleted_record = certipy.store.remove_files("bar", delete_dir=True)
+        assert not os.path.exists(deleted_record["files"]["cert"])
+        assert not os.path.exists(deleted_record["files"]["key"])
 
         # the CA cert should still be around, we have to delete that explicitly
-        assert os.path.exists(deleted_record['files']['ca'])
+        assert os.path.exists(deleted_record["files"]["ca"])
 
         # create an intermediate CA
-        begin_ca_signee_num = len(ca_record['signees'] or {})
-        intermediate_ca = 'bat'
-        intermediate_ca_record = certipy.create_ca(
-            intermediate_ca, ca_name=ca_name, pathlen=1)
-        end_ca_signee_num = len(ca_record['signees'])
+        begin_ca_signee_num = len(ca_record["signees"] or {})
+        intermediate_ca = "bat"
+        certipy.create_ca(intermediate_ca, ca_name=ca_name, pathlen=1)
+        end_ca_signee_num = len(ca_record["signees"])
         intermediate_ca_bundle = certipy.store.get_files(intermediate_ca)
         basic_constraints = intermediate_ca_bundle.cert.get_extension_value(
-            'basicConstraints')
+            "basicConstraints"
+        )
 
         assert end_ca_signee_num > begin_ca_signee_num
-        assert intermediate_ca_bundle.record['parent_ca'] == ca_name
+        assert intermediate_ca_bundle.record["parent_ca"] == ca_name
         assert intermediate_ca_bundle.is_ca()
         assert basic_constraints.path_length == 1
 
+
 def test_certipy_trust_graph():
     trust_graph = {
-        'foo': ['foo', 'bar'],
-        'bar': ['foo'],
-        'baz': ['bar'],
+        "foo": ["foo", "bar"],
+        "bar": ["foo"],
+        "baz": ["bar"],
     }
 
     def distinct_components(graph):
@@ -343,26 +354,29 @@ def test_certipy_trust_graph():
                     bundle = bundles[untrusted_comp]
                     assert str(bundle.cert) not in trust_bundle
 
+
 def test_certs():
     with TemporaryDirectory() as td:
         # Setup
-        ca_name = 'foo'
+        ca_name = "foo"
         certipy = Certipy(store_dir=td)
         ca_record = certipy.create_ca(ca_name, pathlen=-1)
 
-        cert_name = 'bar'
-        alt_names = ['DNS:localhost', 'IP:127.0.0.1']
+        cert_name = "bar"
+        alt_names = ["DNS:localhost", "IP:127.0.0.1"]
         cert_record = certipy.create_signed_pair(
             cert_name, ca_name, alt_names=alt_names
         )
 
-        with tls_server(cert_record['files']['cert'], cert_record['files']['key']) as server:
+        with tls_server(
+            cert_record["files"]["cert"], cert_record["files"]["key"]
+        ) as server:
             # Execute/Verify
-            url = f'https://{server.host}:{server.port}'
+            url = f"https://{server.host}:{server.port}"
 
             # Fails without specifying a CA for verification
             with pytest.raises(SSLError):
                 requests.get(url)
 
             # Succeeds when supplying the CA cert
-            requests.get(url, verify=ca_record['files']['cert'])
+            requests.get(url, verify=ca_record["files"]["cert"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">=3.7"
 dependencies = ["cryptography", "ipaddress"]
 
 [project.optional-dependencies]
-dev = ["pytest", "flask", "requests", "pre-commit", "black", "ruff"]
+dev = ["pytest", "flask", "requests", "pre-commit", "ruff"]
 
 [tool.setuptools.packages.find]
 include = ["certipy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dependencies = ["cryptography", "ipaddress"]
 dev = ["pytest", "flask", "requests"]
 test = ["pytest"]
 
+[tool.setuptools.packages.find]
+include = ["certipy"]
+
 [project.scripts]
 certipy = "certipy.command_line:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,7 @@ requires-python = ">=3.7"
 dependencies = ["cryptography", "ipaddress"]
 
 [project.optional-dependencies]
-dev = ["pytest", "flask", "requests"]
-test = ["pytest"]
+dev = ["pytest", "flask", "requests", "pre-commit", "black", "ruff"]
 
 [tool.setuptools.packages.find]
 include = ["certipy"]


### PR DESCRIPTION
I know there's a lot of change because of `black`. The primary changes of substance:
- The `pre-commit` config, of course
- I added the top-level package for `certipy` to `pyproject.toml` (failed install trying to disambiguate packages `test` and `certipy`)
- I addressed the issues reported by `ruff` so hooks would pass

I'm leaving automatic `ci` out for now.

resolves #13 