### PR TITLE
Remove build from release env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   release-build:
     runs-on: ubuntu-latest
-    environment:
-      name: Release
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Building does not require running in the release environment.