### PR TITLE
remove ipaddress from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers=[
 ]
 keywords = ["pki", "ssl", "tls", "certificates"]
 requires-python = ">=3.7"
-dependencies = ["cryptography", "ipaddress"]
+dependencies = ["cryptography"]
 
 [project.optional-dependencies]
 dev = ["pytest", "flask", "build", "requests", "pre-commit", "ruff", "bump-my-version"]


### PR DESCRIPTION
ipaddress is [in the standard library](https://docs.python.org/3/library/ipaddress.html), [ipaddress on pypi](https://pypi.org/project/ipaddress/) is a backport for older Pythons than we support.

Just noticed this in the conda-forge packaging for 0.2, since ipaddress is unavailable for recent Pythons (unlike pip, where it results in a wheel that is harmless to install, but never gets imported)