### PR TITLE
Add AuthorityKeyIdentifier extension for compatibility with Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,24 @@ concurrency:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.8"
+          - "3.12"
+          - "3.x"
+        include:
+          - os: ubuntu-22.04
+            python: "3.7"
 
     steps:
       - uses: actions/checkout@v4
       - name: setup
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python }}
       - name: install
         run: |
           python -m pip install --upgrade pip

--- a/certipy/certipy.py
+++ b/certipy/certipy.py
@@ -922,6 +922,10 @@ class Certipy:
         cacert = ca_bundle.cert.load()
         cakey = ca_bundle.key.load()
 
+        extensions.append(
+            (x509.AuthorityKeyIdentifier.from_issuer_public_key(cacert.public_key()), False)
+        )
+
         now = datetime.now(timezone.utc)
         eol = now + timedelta(days=years * 365)
         cert = self.sign(

--- a/certipy/test/test_certipy.py
+++ b/certipy/test/test_certipy.py
@@ -53,6 +53,8 @@ def make_flask_app():
     @app.route("/")
     def working():
         return "working"
+    
+    return app
 
 
 @contextmanager

--- a/certipy/test/test_certipy.py
+++ b/certipy/test/test_certipy.py
@@ -383,9 +383,6 @@ def test_certs():
             ssl_context.verify_mode = ssl.CERT_REQUIRED
             ssl_context.load_default_certs()
             ssl_context.load_cert_chain(ca_record["files"]["cert"], ca_record["files"]["key"])
-            # currently required to pass on 3.13
-            # if hasattr(ssl, "VERIFY_X509_STRICT"):
-            #     ssl_context.verify_flags &= ~ssl.VERIFY_X509_STRICT
 
             # Succeeds when supplying the CA cert
             with urlopen(url, context=ssl_context):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">=3.7"
 dependencies = ["cryptography"]
 
 [project.optional-dependencies]
-dev = ["pytest", "flask", "build", "requests", "pre-commit", "ruff", "bump-my-version"]
+dev = ["pytest", "flask", "build", "pre-commit", "ruff", "bump-my-version"]
 
 [tool.setuptools.dynamic]
 version = {attr = "certipy.version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ###############################################################################
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=64", "setuptools_scm>=7"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
3.13 fails with Missing Authority Key Identifier due to new default strictness

I'm not sure what needs to change to fix this, but certipy certificates are not accepted by default with Python 3.13

also adds test coverage for oldest supported Python (3.7) to make sure it really works. Needed some metadata updates to keep working.