### PR TITLE
cryptography 47: serialization.Encoding is no longer a standard Enum

### DIFF
--- a/certipy/certipy.py
+++ b/certipy/certipy.py
@@ -168,7 +168,9 @@ class TLSFile:
 
         self.file_path = file_path
         self.containing_dir = os.path.dirname(self.file_path)
-        self.encoding = serialization.Encoding(encoding)
+        if isinstance(encoding, str):
+            encoding = getattr(serialization.Encoding, encoding)
+        self.encoding = encoding
         self.file_type = file_type
         self.x509 = x509
 


### PR DESCRIPTION
breaking change in cryptography 47: you can't instantiate the Encoding enum anymore

With standard enums, you can use instantiation as a cast:

```python
Enum(value or enum) -> enum
```

but cryptography 47 changes their enum classes to be non-standard, and only usable via attribute access. This approach works with any version of cryptography.